### PR TITLE
Only show homepage when it's actually present

### DIFF
--- a/pkg.pl
+++ b/pkg.pl
@@ -181,7 +181,9 @@ if (@ARGV) {
                 while ( my $row = $ssth->fetchrow_hashref ) {
                     print "Comment:\n$row->{COMMENT}\n\n";
                     print "Description:\n$row->{DESCRIPTION}\n";
-                    print "Homepage:\n$row->{HOMEPAGE}\n";
+                    if($row->{HOMEPAGE}) {
+                        print "Homepage:\n$row->{HOMEPAGE}\n";
+                    }
                 }
                 exit();
             }


### PR DESCRIPTION
My github workflow:
- do a thing
- create a pr
- create another pr to fix the first pr

Not all ports have homepages, unfortunately.
Example: xjewel

Cheers,
Stefan
